### PR TITLE
Allow registration of exports from an external assembly

### DIFF
--- a/Kipon.Dynamics.Plugin/DI/PluginContext.cs
+++ b/Kipon.Dynamics.Plugin/DI/PluginContext.cs
@@ -18,7 +18,7 @@ namespace Kipon.Dynamics.Plugin.DI
         private ITracingService TracingService;
         private IOrganizationService OrganizationService;
 
-        internal PluginContext(string unsecureConfig, string secureConfig, IPluginExecutionContext pluginExecutionContext, ITracingService tracingService, IOrganizationService organizationService, CrmEventType eventType, Guid userid, System.Collections.Generic.Dictionary<Type, object> _di)
+        internal PluginContext(string unsecureConfig, string secureConfig, IPluginExecutionContext pluginExecutionContext, ITracingService tracingService, IOrganizationService organizationService, CrmEventType eventType, Guid userid, System.Collections.Generic.Dictionary<Type, object> _di, Type callingType)
         {
             this.UnsecureConfig = unsecureConfig;
             this.SecureConfig = secureConfig;
@@ -28,6 +28,7 @@ namespace Kipon.Dynamics.Plugin.DI
             this.EventType = eventType;
             this.UserId = userid;
             this.di = _di;
+            serviceFactory.RegisterExternalExports(callingType);
         }
 
         public string UnsecureConfig { get; private set; }

--- a/Kipon.Dynamics.Plugin/DI/ServiceFactory.cs
+++ b/Kipon.Dynamics.Plugin/DI/ServiceFactory.cs
@@ -35,6 +35,26 @@ namespace Kipon.Dynamics.Plugin.DI
             exports = GetTypesWithExportAttribute();
         }
 
+        public void RegisterExternalExports(Type callingType)
+        {
+            var assembly = callingType.Assembly;
+            var exportAttribute = typeof(Export);
+            var result = new Dictionary<Type, Type>();
+            foreach (Type type in assembly.GetTypes())
+            {
+                var ea = type.GetCustomAttributes(exportAttribute, true).SingleOrDefault() as Export;
+                if (ea != null)
+                {
+                    if (!exports.ContainsKey(ea.Type))
+                    {
+                        exports.Add(ea.Type, type);
+                    }
+
+                }
+            }
+
+        }
+
         public static ServiceFactory Instance
         {
             get

--- a/Kipon.Dynamics.Plugin/Plugins/AbstractBasePlugin.cs
+++ b/Kipon.Dynamics.Plugin/Plugins/AbstractBasePlugin.cs
@@ -10,9 +10,13 @@ namespace Kipon.Dynamics.Plugin.Plugins
         public string UnsecureConfig { get; private set; }
         public string SecureConfig { get; private set; }
 
+        private Type _callingType;
+
         #region constructors
         public AbstractBasePlugin() : base()
         {
+            // The plugin services may exist in an external assembly so hold the calling type to register external exports with the DI container
+            _callingType = this.GetType();
         }
 
         public AbstractBasePlugin(string unSecure, string secure) : base()
@@ -49,7 +53,7 @@ namespace Kipon.Dynamics.Plugin.Plugins
 
             try
             {
-                var pc = new DI.PluginContext(this.UnsecureConfig, this.SecureConfig, context, tracingService, service, et, context.UserId, di);
+                var pc = new DI.PluginContext(this.UnsecureConfig, this.SecureConfig, context, tracingService, service, et, context.UserId, di, _callingType);
                 di.Add(typeof(IServiceProvider), serviceProvider);
                 di.Add(typeof(IOrganizationServiceFactory), serviceFactory);
                 di.Add(typeof(IPluginExecutionContext), context);


### PR DESCRIPTION
I'm using a slightly modified version for another project where the DI classes are in a core assembly that my plugin projects reference.

This change allows that by registering the exports from the derived class assembly.